### PR TITLE
[20221214 홍준성 -1]

### DIFF
--- a/src/main/java/com/example/myoceanproject/controller/communtiy/CommunityRestController.java
+++ b/src/main/java/com/example/myoceanproject/controller/communtiy/CommunityRestController.java
@@ -57,6 +57,7 @@ public class CommunityRestController {
     //  비회원 전용 리스트 출력
     @GetMapping("/list-not-user")
     public List<CommunityPostDTO> getCommunity(){
+
         List<CommunityPostDTO> communityPostDTO= communityPostService.findAllByList();
         return communityPostDTO;
     }
@@ -71,24 +72,39 @@ public class CommunityRestController {
     public List<CommunityPostDTO> getFilterCommunity(@PathVariable("communityCategories") List<String> communityCategories, HttpServletRequest request){
         HttpSession session = request.getSession();
         Long userId = (Long) session.getAttribute("userId");
-
         List<CommunityPostDTO> communityPostDTO = communityPostService.findBoardByCategory(communityCategories, userId);
         return communityPostDTO;
     }
 
-    //무한스크롤
-    @GetMapping("/scroll/{page}")
-    public List<CommunityPostDTO> infiniteScroll(@PathVariable int page){
-        return communityPostService.selectScrollBoards(page);
+    //무한스크롤 비회원전용(카테고리 있을 때)
+    @GetMapping("/scroll/{page}/{communityCategories}")
+    public List<CommunityPostDTO> infiniteScroll(@PathVariable int page, @PathVariable("communityCategories") List<String> communityCategories){
+        return communityPostService.findBoardByCategory(page, communityCategories);
     }
 
-    //무한스크롤 회원전용
-    @GetMapping("/scroll-user/{page}")
-    public List<CommunityPostDTO> selectScrollBoards(@PathVariable int page, HttpServletRequest request){
-        HttpSession session = request.getSession();
+
+    //무한스크롤 비회원전용(카테고리 없을 때)
+    @GetMapping("/scroll/{page}/")
+    public List<CommunityPostDTO> infiniteScroll(@PathVariable int page){
+        return communityPostService.findBoardByCategory(page);
+    }
+
+    //무한스크롤 회원전용(카테고리 있을 때)
+    @GetMapping("/scroll-user/{page}/{communityCategories}")
+    public List<CommunityPostDTO> selectScrollBoards(@PathVariable int page, @PathVariable("communityCategories") List<String> communityCategories, HttpSession session){
+
         Long userId = (Long) session.getAttribute("userId");
 
-        return communityPostService.selectScrollBoards(page, userId);
+        return communityPostService.findBoardByCategory(page, communityCategories, userId);
+    }
+
+    //무한스크롤 회원전용(카테고리 없을 때)
+    @GetMapping("/scroll-user/{page}/")
+    public List<CommunityPostDTO> selectScrollBoards(@PathVariable int page, HttpSession session){
+
+        Long userId = (Long) session.getAttribute("userId");
+
+        return communityPostService.findBoardByCategory(page, userId);
     }
 
     // 게시글 작성 후 커뮤니티 페이지로 이동

--- a/src/main/java/com/example/myoceanproject/controller/host/HostController.java
+++ b/src/main/java/com/example/myoceanproject/controller/host/HostController.java
@@ -51,7 +51,7 @@ public class HostController {
 
     // 게시글 상세보기
     @GetMapping("/read")
-    public String read(Long groupId, Model model, Model model2, Model model3, Model model4, Model model5, HttpServletRequest request) throws UnsupportedEncodingException{
+    public String read(Long groupId, Model model, Model model2, Model model3, Model model4, Model model5, Model model6, HttpServletRequest request) throws UnsupportedEncodingException{
         HttpSession session= request.getSession();
         Long userId = (Long) session.getAttribute("userId");
 
@@ -59,8 +59,15 @@ public class HostController {
         model2.addAttribute("groupTop5DTOs", groupService.findTop5BygroupId(groupId));
         model3.addAttribute("groupScheduleDTO", groupService.findAllByGroupId(groupId));
         model4.addAttribute("localDateTime", LocalDateTime.now());
-        model5.addAttribute("groupUserCheck", groupService.findGroupUser(userId));
-        log.info(model5.toString());
+        if(userId != null){
+            model5.addAttribute("groupUserCheck", groupService.findGroupUser(userId, groupId));
+        } else{
+            model5 = null;
+        }
+
+        model6.addAttribute("groupJoinMember", groupService.countGroupMember(groupId));
+
+
         return "app/bulletin_board/bulletin_board_detail";
     }
 

--- a/src/main/java/com/example/myoceanproject/controller/host/HostRestController.java
+++ b/src/main/java/com/example/myoceanproject/controller/host/HostRestController.java
@@ -91,7 +91,7 @@ public class HostRestController {
     // 스케줄 저장
     @PostMapping(value="/addDate/{groupId}", consumes = "application/json", produces = "text/plain; charset=utf-8")
     public ResponseEntity<String> schedule(@RequestBody GroupScheduleDTO groupScheduleDTO, @PathVariable("groupId") Long groupId) throws UnsupportedEncodingException {
-
+        log.info(groupScheduleDTO.toString());
         groupScheduleDTO.setGroupId(groupId);
 
         groupService.addSchedule(groupScheduleDTO);
@@ -212,7 +212,7 @@ public class HostRestController {
             log.info("scheduleDate" + scheduleDate);
             if(simpleDate.equals(scheduleDate)){
                 groupScheduleId = groupScheduleDTO.getGroupScheduleId();
-            };
+            }
         }
         groupScheduleService.delete(groupScheduleId);
     }
@@ -248,5 +248,23 @@ public class HostRestController {
         out.println("/upload/groupUpload/"+storedFileName + originalFileExtension);
         out.close();
     }
+
+    // 게시글 임시 저장 시 모임 등록 헤더 변경
+    @GetMapping("/header")
+    public GroupDTO getHeader(HttpServletRequest request){
+        HttpSession session = request.getSession();
+        Long userId = (Long) session.getAttribute("userId");
+        log.info("============================");
+        log.info("============================");
+        log.info("============================");
+        log.info("============================");
+        log.info("여기로 들어옴");
+        GroupDTO groupDTO = groupService.findByUserId(userId);
+        log.info(groupDTO.toString());
+
+        return groupDTO;
+    }
 }
+
+
 

--- a/src/main/java/com/example/myoceanproject/repository/community/like/CommunityLikeRepositoryImpl.java
+++ b/src/main/java/com/example/myoceanproject/repository/community/like/CommunityLikeRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.example.myoceanproject.entity.CommunityLike;
 import com.example.myoceanproject.entity.CommunityPost;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,6 +13,7 @@ import static com.example.myoceanproject.entity.QCommunityLike.communityLike;
 
 @Repository
 @RequiredArgsConstructor
+@Slf4j
 public class CommunityLikeRepositoryImpl implements CommunityLikeCustomRepository{
 //사용자 지정 레파지토리 Impl(구현)
 

--- a/src/main/java/com/example/myoceanproject/repository/community/post/CommunityPostCustomRepository.java
+++ b/src/main/java/com/example/myoceanproject/repository/community/post/CommunityPostCustomRepository.java
@@ -24,5 +24,8 @@ public interface CommunityPostCustomRepository {
 
     public List<CommunityPostDTO> filterCommunityBoard(List<String> communityCategories);
 
+    public List<CommunityPostDTO> filterCommunityBoard(int page, List<String> communityCategories);
+
     public List<CommunityPostDTO> filterCommunityBoard(List<String> communityCategories, Long userId);
+    public List<CommunityPostDTO> filterCommunityBoard(int page, List<String> communityCategories, Long id);
 }

--- a/src/main/java/com/example/myoceanproject/repository/community/reply/CommunityReplyRepositoryImpl.java
+++ b/src/main/java/com/example/myoceanproject/repository/community/reply/CommunityReplyRepositoryImpl.java
@@ -44,7 +44,7 @@ public class CommunityReplyRepositoryImpl implements CommunityReplyCustomReposit
                 communityReply.communityPost.user.userId
         )).from(communityReply)
                 .where(communityPost.communityPostId.eq(communityPostId))
-                .orderBy(communityReply.createDate.desc()).fetch();
+                .orderBy(communityReply.createDate.asc()).fetch();
 
         return replies;
     }

--- a/src/main/java/com/example/myoceanproject/service/GroupService.java
+++ b/src/main/java/com/example/myoceanproject/service/GroupService.java
@@ -91,14 +91,23 @@ public class GroupService implements GroupBoardService {
         return criteria.getKeyword().equals("null") ? groupRepositoryImpl.findAllByStatus(pageable, groupStatus) : groupRepositoryImpl.findAllByStatus(pageable,groupStatus, criteria);
     }
 
-    public boolean findGroupUser(Long userId){
-        return groupRepositoryImpl.countGroupUser(userId) == 1;
+    public boolean findGroupUser(Long userId, Long groupId){
+        return groupRepositoryImpl.countGroupUser(userId, groupId);
     }
 
 
     @Transactional(rollbackFor = Exception.class)
     public void deleteMember(Long userId, Long groupId){
         groupRepositoryImpl.deleteGroupMemberByUserId(userId, groupId);
+    }
+
+    public int countGroupMember(Long groupId){
+        return groupRepositoryImpl.countMember(groupId);
+    }
+
+    public GroupDTO findByUserId(Long userId){
+        GroupDTO groupDTO = groupRepositoryImpl.findByUserId(userId);
+        return groupDTO;
     }
 
 }

--- a/src/main/java/com/example/myoceanproject/service/community/CommunityPostService.java
+++ b/src/main/java/com/example/myoceanproject/service/community/CommunityPostService.java
@@ -79,10 +79,47 @@ public class CommunityPostService implements CommunityService {
         return communityPostDTO;
     }
 
+//    비회원 전용
+    public List<CommunityPostDTO> findBoardByCategory(int page, List<String> communityCategories){
+        List<CommunityPostDTO> communityPostDTO = postRepositoryImpl.filterCommunityBoard(page, communityCategories);
+        return communityPostDTO;
+    }
+
+//    비회원 전용(카테고리 없을 때)
+    public List<CommunityPostDTO> findBoardByCategory(int page){
+        List<CommunityPostDTO> communityPostDTO = postRepositoryImpl.filterCommunityBoard(page);
+        return communityPostDTO;
+    }
+
+
+
+
+
+//  회원 전용
+    public List<CommunityPostDTO> findBoardByCategory(int page, List<String> communityCategories, Long userId){
+        log.info("===============" + userId);
+        List<CommunityPostDTO> communityPostDTO = postRepositoryImpl.filterCommunityBoard(page, communityCategories, userId);
+        return communityPostDTO;
+    }
+
+//  회원 전용(카테고리 없을 때)
+    public List<CommunityPostDTO> findBoardByCategory(int page, Long userId){
+        log.info("===============" + userId);
+        List<CommunityPostDTO> communityPostDTO = postRepositoryImpl.filterCommunityBoard(page, userId);
+        return communityPostDTO;
+    }
+
+
+
+
+
+
     public List<CommunityPostDTO> findBoardByCategory(List<String> communityCategories, Long userId){
         List<CommunityPostDTO> communityPostDTO = postRepositoryImpl.filterCommunityBoard(communityCategories, userId);
         return communityPostDTO;
     }
+
+
 
 
     @Override

--- a/src/main/resources/static/css/bulletin_board/bulletin.css
+++ b/src/main/resources/static/css/bulletin_board/bulletin.css
@@ -453,3 +453,4 @@ button, input, select, textarea {
 .page {
     cursor:pointer;
 }
+

--- a/src/main/resources/static/css/community/detail.css
+++ b/src/main/resources/static/css/community/detail.css
@@ -1845,8 +1845,16 @@ td{
     margin: 8px;
 }
 
-
-
+.bJFgwb {
+    margin: 0px;
+    overflow: hidden auto;
+    transform-origin: left top;
+    white-space: pre-line;
+    font-size: 14px;
+    line-height: 22px;
+    padding: 24px 24px 12px;
+    transform: translateY(0px) scale(1, 1);
+}
 
 
 

--- a/src/main/resources/static/js/bulletin_board/bulletin_board_detail.js
+++ b/src/main/resources/static/js/bulletin_board/bulletin_board_detail.js
@@ -1,4 +1,22 @@
 
+$("article div.LinkAccordion__AccordionContainer-sc-1o112j5-1.cJPEO").on("click", "#noticeWrap", function(){
+    if($("#notice").attr("class")== "Accordion__Content-sc-1jd6vdl-3 zRWUs"){
+        $("#notice").attr("class", "Accordion__Content-sc-1jd6vdl-3 bJFgwb");
+    } else{
+        $("#notice").attr("class", "Accordion__Content-sc-1jd6vdl-3 zRWUs");
+    }
+})
+
+$("#refundWrap").on("click", function(){
+    if($("#refund").attr("class")== "Accordion__Content-sc-1jd6vdl-3 zRWUs"){
+        console.log("열림");
+        $("#refund").attr("class", "Accordion__Content-sc-1jd6vdl-3 bJFgwb");
+    }else{
+        console.log("닫힘");
+        $("#refund").attr("class", "Accordion__Content-sc-1jd6vdl-3 zRWUs");
+    }
+})
+
 
 // 참여하기
 $(".joinGroup").on("click", function(){

--- a/src/main/resources/static/js/community/comment.js
+++ b/src/main/resources/static/js/community/comment.js
@@ -35,7 +35,6 @@ $textarea.keyup(function (e) {
     if(content.length==0 || content==''){
         $registerBtn.css("cursor","not-allowed");
         $registerBtn.prop("disabled", true);
-
     }else{
         $registerBtn.css("cursor","pointer");
         $registerBtn.prop("disabled", false);

--- a/src/main/resources/static/js/community/community.js
+++ b/src/main/resources/static/js/community/community.js
@@ -9,6 +9,7 @@ const $book = $(".bookFilter")
 const $diary = $(".diaryFilter")
 
 globalThis.communityAr = new Array();
+
 let communities = ['EXERCISE', 'COOK', 'MOVIE', 'BOOK', 'COUNSELING'];
 
 
@@ -117,7 +118,7 @@ function allCheckCancel(){
 
 
 $allBtn.on("click",function () {
-    
+
   if($(this).find("button").hasClass("fFBpBV")){
       allCheck();
       $filterBtn.each((i,item)=>{
@@ -235,7 +236,6 @@ let communityLikeCheck = false;
 
 let communityService = (function() {
     function getList(param, callback, error) {
-        console.log(param);
         $.ajax({
             url: "/community/list/",
             type: "get",
@@ -268,9 +268,9 @@ let communityService = (function() {
         });
     }
 
-    function infiniteScroll(page, callback, error){
+    function infiniteScroll(param, callback, error){
         $.ajax({
-            url: "/community/scroll/" + page,
+            url: "/community/scroll/" + param.page + "/" + param.keyword,
             type: "get",
             success: function(boards, status, xhr){
                 if(callback){
@@ -285,9 +285,9 @@ let communityService = (function() {
         });
     }
 
-    function infiniteScrollUser(page, callback, error){
+    function infiniteScrollUser(param, callback, error){
         $.ajax({
-            url: "/community/scroll-user/" + page,
+            url: "/community/scroll-user/" + param.page + (("/" + param.keyword) || ""),
             type: "get",
             success: function(boards, status, xhr){
                 if(callback){
@@ -357,7 +357,7 @@ let communityService = (function() {
 
     function filterCheck(communityCategories, callback, error){
         $.ajax({
-            url: "/community/list-filter/" + communityCategories,
+            url: "/community/list-filter/" + globalThis.communityAr,
             type: "get",
             success: function(communityCategories, status, xhr){
                 if(callback){
@@ -373,7 +373,7 @@ let communityService = (function() {
 
     function filterCheckLoginUser(communityCategories, callback, error){
         $.ajax({
-            url: "/community/list-filter-login-user/" + communityCategories,
+            url: "/community/list-filter-login-user/" + globalThis.communityAr,
             type: "get",
             success: function(communityCategories, status, xhr){
                 if(callback){
@@ -394,18 +394,31 @@ let communityService = (function() {
 
 
 let page = 1;
-
+let scrollCheck = false;
 $(window).scroll(function(){
     if($(window).scrollTop() * 1.001 >= $(document).height() - $(window).height()){
+        if(scrollCheck){
+            return;
+        }
+        scrollCheck = true;
         showCheck=true;
+        console.log(globalThis.communityAr);
         if($("input[name='userId']").val()){
-            communityService.infiniteScrollUser(page, getList);
-            page++;
+            communityService.infiniteScrollUser({
+                page:page,
+                keyword: globalThis.communityAr
+            }, getList);
         }
         else{
-            communityService.infiniteScroll(page, getList);
-            page++;
+            communityService.infiniteScroll({
+                page:page,
+                keyword: globalThis.communityAr
+            }, getList);
         }
+        page++;
+        setTimeout(function(){
+            scrollCheck = false;
+        }, 500);
     }
 });
 
@@ -461,6 +474,7 @@ let showCheck = true;
 
 // 커뮤니티 카테고리 동적쿼리
 $(".jJIWoq").on("click", function(){
+    page = 1;
     showCheck = false;
 
     if($("input[name='userId']").val()==""){

--- a/src/main/resources/static/js/community/detail.js
+++ b/src/main/resources/static/js/community/detail.js
@@ -60,3 +60,11 @@ $(".goDeleteCommunity").on("click", function(e){
     e.preventDefault();
     location.href ="/community/deleteBoard?communityPostId=" + $(this).attr("href");
 })
+
+$("#noticeWrap").on("click", function(){
+    if($("#notice").attr("class") == "Accordion__Content-sc-1jd6vdl-3 zRWUs"){
+        $("#notice").attr("class", "Accordion__Content-sc-1jd6vdl-3 bJFgwb");
+    } else{
+        $("#notice").attr("class", "Accordion__Content-sc-1jd6vdl-3 zRWUs");
+    }
+})

--- a/src/main/resources/static/js/host/host.js
+++ b/src/main/resources/static/js/host/host.js
@@ -277,6 +277,14 @@ function showPlaceDetail(){
     }
 }
 
+$("input[name='groupPoint']").keyup(function(){
+    if($("input[name='groupPoint']").val()>10000){
+        alert("포인트는 10,000 이상 설정하실 수 없습니다.");
+        $("input[name='groupPoint']").focus();
+    }
+})
+
+
 // 모달창 닫기
 function closeModal(){
     $('#__BVID__287___BV_modal_outer_').hide();
@@ -290,12 +298,42 @@ function findPlace(){
         return;
     }
 
+
+
     $('#__BVID__287___BV_modal_outer_').show();
     $('#__BVID__287___BV_modal_content_').show();
     $('#__BVID__1216___BV_modal_content_').hide();
     $('#__BVID__21___BV_modal_content_').hide();
     $('#__BVID__123___BV_modal_content_').hide();
 }
+
+// 장소 추가 유효성 검사
+$(".createPlace.btn.frip-button.btn-frip-primary.btn-tab").on("click", function(){
+    if($("input[name='locationName']").val()==""){
+        alert("장소명을 입력해주세요.");
+        $("input[name='locationName']").focus();
+        return;
+    }
+
+    if(!checkedLogion){
+        alert('해외장소 여부를 선택해주세요');
+        return;
+    }
+
+    if($("input[id='placeAddress']").val()==""){
+        alert("주소를 입력해주세요.");
+        $("input[id='placeAddress']").focus();
+        return;
+    }
+
+    if($("input[id='locationDetail']").val()==""){
+        alert("상세 주소를 입력해주세요.");
+        $("input[id='placeAddress']").focus();
+        return;
+    }
+
+    closeModal();
+})
 
 let checkedLogion = false;
 //국내 || 해외 선택
@@ -317,14 +355,24 @@ $('.clearPlace').on('click', function(){
     $('.findPlace').show();
 });
 
+// 편집 진행 시 장소 테이블에 나오도록 진행
+$(function(){
+    if($(".text-sm")[0].innerText != "신규등록"){
+        if($('input[data-v-72dffd28]').eq(14).val() != "" && $('#placeAddress').val() != ""){
+            $('.placeTable .placeName').text($("input[name='locationName']").val());
+            $('.placeTable .placeAddr').text($('#placeAddress').val());
+            $('.my-2.placeTable').css("display", "block");
+            $('.placeTableBtn').css("display", "block");
+            $('.findPlace').hide();
+            $(".place").show();
+        }
+    }
+})
+
 // 진행 장소 등록 버튼 클릭 이벤트막기
 $('.createPlace').on('click', function(e){
     if($('input[data-v-72dffd28]').eq(12).val() == ""){
         $('input[data-v-72dffd28]').eq(12).blur();
-    }
-
-    if(!checkedLogion){
-        alert('해외장소 여부를 선택해주세요');
     }
 
     if($('#placeAddress').val() == ""){
@@ -340,9 +388,9 @@ $('.createPlace').on('click', function(e){
         $('.placeTableBtn').show();
         $('.findPlace').hide();
 
-        closeModal();
     }
 });
+
 $('#placeAddress').on('blur', function(){
     if(!$(this).val()){
         $(this).attr('class', 'form-control is-invalid');
@@ -355,6 +403,7 @@ $('#placeAddress').on('blur', function(){
 
 // 일정 추가 버튼 클릭 -> 모달창 열기
 function addSchedule() {
+    let dateCheck = false;
     // 일정 추가 버튼 유효성 검사
     if ($(".cancelRecruitment").css("display") == "none") {
         alert("일정 설정은 저장 후 가능합니다.");
@@ -362,43 +411,36 @@ function addSchedule() {
     }
 
     $(".table").on("click", ".day-btn", function(){
-        console.log($(this).parent().parent().next().children().text());
         if($(this).parent().parent().next().children().text()){
-            let scheduleDeleteMsg = confirm($(".mx-3.dateTitle").text() + $(this).parent().next().text() + " " +  $(this).parent().parent().next().children().text().trim() + "에 진행 예정인 모임 일정을 삭제하시겠습니까?");
-            if(scheduleDeleteMsg){
-                let scheduleDate = $(this).attr("data-date");
-                let groupId = $('input[name=groupId]').val();
-                // 삭제
-                $.ajax({
-                    url: "/host/delete-schedule/" + groupId + "/" + scheduleDate,
-                    type: "post",
-                    async: false,
-                    success: function(){
-                        showList();
-                        console.log("들어옴");
-                        return;
-                        console.log("나감");
-                    }
-                });
-            }else{;}
+            // alert($(".mx-3.dateTitle").text() + $(this).parent().next().text() + " " +  $(this).parent().parent().next().children().text().trim() + "에 진행 예정인 모임 일정을 삭제합니다.");
+            let scheduleDate = $(this).attr("data-date");
+            let groupId = $('input[name=groupId]').val();
+            // 삭제
+            $.ajax({
+                url: "/host/delete-schedule/" + groupId + "/" + scheduleDate,
+                type: "post",
+                async: false,
+                success: function(){
+                    showList();
+                }
+            });
+        } else{
+            $('#__BVID__287___BV_modal_outer_').show();
+            $('#__BVID__287___BV_modal_content_').hide();
+            $('#__BVID__21___BV_modal_content_').hide();
+            $('#__BVID__123___BV_modal_content_').hide();
+            $('#__BVID__1216___BV_modal_content_').show();
+
+            $('input[type=date]').val($(this).attr('data-date'));
+            let selDate = new Date($('input[type=date]').val());
+            selDate < date ? $('.dateNotice').css('display', '') : $('.dateNotice').css('display', 'none');
+            if ($('input[type=date]').val()) {
+                $('.periodNotice').text(`${selDate.getFullYear()}년 ${selDate.getMonth() + 1}월 ${selDate.getDate()}일까지 모임을 신청할 수 있습니다.`);
+            } else {
+                $('.periodNotice').text(`날짜를 입력해주세요`);
+            }
         }
     })
-
-
-    $('#__BVID__287___BV_modal_outer_').show();
-    $('#__BVID__287___BV_modal_content_').hide();
-    $('#__BVID__21___BV_modal_content_').hide();
-    $('#__BVID__123___BV_modal_content_').hide();
-    $('#__BVID__1216___BV_modal_content_').show();
-
-    $('input[type=date]').val($(this).attr('data-date'));
-    let selDate = new Date($('input[type=date]').val());
-    selDate < date ? $('.dateNotice').css('display', '') : $('.dateNotice').css('display', 'none');
-    if ($('input[type=date]').val()) {
-        $('.periodNotice').text(`${selDate.getFullYear()}년 ${selDate.getMonth() + 1}월 ${selDate.getDate()}일까지 대원이 신청할 수 있습니다.`);
-    } else {
-        $('.periodNotice').text(`날짜를 입력해주세요`);
-    }
 }
 
 //일정 시간 유효성 검사
@@ -409,6 +451,7 @@ $('.openTime').on('change', function (){
     let openTime = new Date();
     let closeTime = new Date();
 
+
     openTime.setHours(open[0]);
     openTime.setMinutes(open[1]);
     closeTime.setHours(close[0]);
@@ -416,9 +459,6 @@ $('.openTime').on('change', function (){
 
     let differ = (closeTime.getTime() - openTime.getTime()) / (1000*60*60)
 
-    console.log("openTime" + openTime);
-    console.log("closeTime" + closeTime);
-    console.log(openTime > closeTime);
 
     if(openTime > closeTime){
         console.log('dd');
@@ -431,6 +471,8 @@ $('.openTime').on('change', function (){
         $('.timeNotice').css('display', 'none');
     }
 });
+
+
 
 
 //일정 등록
@@ -516,9 +558,6 @@ $(".plusThumb").on("change", function(){
             $('input[name=groupFileSize]').attr('value', Object.values(result[0])[22]);
             $('input[name=groupFileUuid]').attr('value', Object.values(result[0])[21]);
             let imageSrc = "/host/display?fileName=" + Object.values(result[0])[19] + "/" + Object.values(result[0])[21] + "_" + Object.values(result[0])[20];
-            console.log(result[0].groupFilePath);
-            console.log(Object.values(result[0]));
-            console.log(imageSrc);
 
             if($('input[name=groupFileSize]').val()>100000){
                 alert("파일 사이즈는 10MB 이하여야합니다.");
@@ -580,6 +619,12 @@ $('.checkRequest').on('click', function (){
         return;
     }
 
+    if($("input[name='groupPoint']")>10000 || !$("input[name='groupPoint']")){
+        alert("금액을 10,000원 이하로 기재해주세요.");
+        $("input[name='groupPoint']").focus();
+        return;
+    }
+
     if($('input[name=groupContent]').val() === ''){
         alert('모임 설명을 확인해주세요');
         $('#__BVID__287___BV_modal_outer_').hide();
@@ -616,7 +661,6 @@ $('.checkRequest').on('click', function (){
         console.log("장소등록");
         if($('.my-2.placeTable').css('display')=='none'){
             console.log("장소등록리턴");
-
             return;
         }
     }
@@ -658,7 +702,6 @@ let groupSave = (function(){
             data: JSON.stringify(groupContents),
             contentType: "application/json; charset=utf-8",
             success: function(result, status, xhr) {
-                console.log(result);
                 $(".text-sm").text(result);
                 if (callback) {
                     callback(result);
@@ -750,7 +793,24 @@ let groupSave = (function(){
         });
     }
 
-    return {add: add, update: update, updateStatus: updateStatus, addDate: addDate, listDate: listDate}
+    function hostHeader(param, callback, error){
+        $.ajax({
+            url: "/host/header",
+            type: "get",
+            async: false,
+            success: function(groupDTO, status, xhr){
+                if(callback){
+                    callback(groupDTO);
+                }
+            }, error: function(xhr, status, err){
+                if(error){
+                    error(err);
+                }
+            }
+        }, hostHeader);
+    }
+
+    return {add: add, update: update, updateStatus: updateStatus, addDate: addDate, listDate: listDate, hostHeader: hostHeader}
 })();
 
 // 모임 페이지 삭제
@@ -816,7 +876,7 @@ $('.saveRequest').on('click', function (e){
     $('input[name=groupContent]').attr('value', content);
 
     if($(".note-editable").text().length>10000){
-        alert("글자는 255자 이내로 작성 가능합니다.");
+        alert("글자는 10,000자 이내로 작성 가능합니다.");
         return;
     }
 
@@ -840,7 +900,7 @@ $('.saveRequest').on('click', function (e){
             groupFilePath : $('input[name=groupFilePath]').val(),
             groupFileSize : $('input[name=groupFileSize]').val(),
             groupFileUuid : $('input[name=groupFileUuid]').val()
-        })
+        }, showHeader);
     }
 
     /*게시글 수정일 때*/
@@ -869,7 +929,7 @@ function groupUpdate(){
         groupFileSize : $('input[name=groupFileSize]').val(),
         groupFileUuid : $('input[name=groupFileUuid]').val(),
         groupId : $('input[name=groupId]').val()
-    });
+    }, showHeader);
 }
 
 
@@ -967,3 +1027,36 @@ $(document).ready(function() {
 function showList(){
     groupSave.listDate(groupId,listDate);
 }
+
+// 게시글 임시 저장, 또는 업데이트 시 상단 부분 변경
+function hostHeader(groupDTO){
+    console.log(groupDTO);
+    let groupText = "";
+    groupText += `<div><div data-v-59b7de29="" className="row"><div data-v-59b7de29="" className="col"><fieldset data-v-59b7de29="" className="form-group" id="__BVID__579"><div>`;
+    groupText += `<label className="form-control-label">ID</label>`;
+    if(groupDTO.groupId){
+        groupText += `<div>groupDTO.groupId</div>`;
+    } else{
+        groupText =`<div className="text-sm">신규등록</div>`;
+    }
+    groupText += `</div></fieldset></div><div data-v-59b7de29="" className="col"><fieldset data-v-59b7de29="" className="form-group" id="__BVID__581"><div>`;
+    groupText += `<label className="form-control-label">상태</label><div className="text-sm">`;
+    if(groupDTO.groupStatus == '승인완료'){
+        groupText += `<div data-v-59b7de29="" className="text-frip-primary font-weight-bold">승인 대기중</div>`;
+    } else{
+        groupText += `<div data-v-59b7de29="" className="text-frip-primary font-weight-bold">등록중</div>`;
+    }
+    groupText += `</div></div></fieldset></div><div data-v-59b7de29="" className="col"><fieldset data-v-59b7de29="" className="form-group" id="__BVID__583"><div>`;
+    groupText += `<label className="form-control-label">검수상태</label>`;
+    if(groupDTO.groupStatus == '승인대기'){
+        groupText += `<div data-v-59b7de29="" className="text-muted font-weight-bold"> 검수 진행중</div>`;
+    } else{
+        groupText +=`<div data-v-59b7de29="" className="text-muted font-weight-bold"> 검수 미신청</div></div>`;
+    }
+
+    groupText+=`<div className="text-sm">`;
+    groupText+= `</div></div></fieldset></div></div></div>`;
+
+    $("#groupHeader").html(groupText);
+}
+

--- a/src/main/resources/templates/app/bulletin_board/bulletin_board_detail.html
+++ b/src/main/resources/templates/app/bulletin_board/bulletin_board_detail.html
@@ -153,11 +153,11 @@
                             </div>
                             <div>
                                 <dt>참여 현황</dt>
-                                <dd th:text="|${#lists.size(groupDTO)} / *{maxMember} 명|"></dd>
+                                <dd th:text="|${groupJoinMember} / *{maxMember} 명|"></dd>
                             </div>
                             <div>
                                 <dt>장소</dt>
-                                <dd th:if="*{groupLocationName}" th:text="|*{groupLocationName} *{groupLocation} *{groupLocationDetail}|">ㄴㄴ</dd>
+                                <dd th:if="*{groupLocationName}" th:text="|*{groupLocationName} *{groupLocation} *{groupLocationDetail}|"></dd>
                                 <dd th:unless="*{groupLocationName}">온라인</dd>
                             </div>
                             <div>
@@ -246,7 +246,7 @@
                     <!--유의사항-->
                     <article>
                         <div class="LinkAccordion__AccordionContainer-sc-1o112j5-1 cJPEOD">
-                            <div class="Accordion__Container-sc-1jd6vdl-0 eGMegW">
+                            <div id="noticeWrap" class="Accordion__Container-sc-1jd6vdl-0 eGMegW">
                                 <div>
                                     유의 사항
                                 </div>
@@ -254,7 +254,7 @@
                                     <img src="data:image/svg+xml,%3Csvg width='7' height='12' viewBox='0 0 7 12' fill='none' xmlns='http://www.w3.org/2000/svg'%3E %3Cpath d='M1 11L6 6L1 1' stroke='%23CCCCCC' stroke-linecap='round' stroke-linejoin='round'/%3E %3C/svg%3E" alt="Arrcodion arrow" class="Accordion__IconArrow-sc-1jd6vdl-2 ewyXrB">
                                 </div>
                             </div>
-                            <div class="Accordion__Content-sc-1jd6vdl-3 zRWUs">
+                            <div id="notice" class="Accordion__Content-sc-1jd6vdl-3 zRWUs">
                                 · 최소 인원 미달로 인해 진행이 취소될 경우, 신청 마감 일시에 진행 취소 안내를 드리며 참가비는 전액 환불해 드립니다.
                             </div>
                         </div>
@@ -262,7 +262,7 @@
                     <!--환불정책-->
                     <article>
                         <div class="LinkAccordion__AccordionContainer-sc-1o112j5-1 cJPEOD">
-                            <div class="Accordion__Container-sc-1jd6vdl-0 eGMegW">
+                            <div id="refundWrap" class="Accordion__Container-sc-1jd6vdl-0 eGMegW">
                                 <div>
                                     환불 정책
                                 </div>
@@ -270,8 +270,8 @@
                                     <img src="data:image/svg+xml,%3Csvg width='7' height='12' viewBox='0 0 7 12' fill='none' xmlns='http://www.w3.org/2000/svg'%3E %3Cpath d='M1 11L6 6L1 1' stroke='%23CCCCCC' stroke-linecap='round' stroke-linejoin='round'/%3E %3C/svg%3E" alt="Arrcodion arrow" class="Accordion__IconArrow-sc-1jd6vdl-2 ewyXrB">
                                 </div>
                             </div>
-                            <div class="Accordion__Content-sc-1jd6vdl-3 zRWUs">
-                                1. 결제 후 1시간 이내에는 무료 취소가 가능합니다. (단, 신청마감 이후 취소 시, 모임 진행 당일 결제 후 취소 시 취소 및 환불 불가) 2. 결제 후 1시간이 초과한 경우, 아래의 환불규정에 따라 취소수수료가 부과됩니다. - 신청마감 2일 이전 취소시 : 전액 환불 - 신청마감 1일 ~ 신청마감 이전 취소시 : 결제 금액의 50% 취소 수수료 배상 후 환불 - 신청마감 이후 취소시, 또는 당일 불참 : 환불 불가 ※ 다회권의 경우, 1회라도 사용시 부분 환불이 불가하며, 기간 내 주최자와 예약 확정 되지 않은 모임은 모임 포인트로 환불 됩니다. ※ 취소 수수료는 신청 마감일을 기준으로 산정됩니다. ※ 신청 마감일은 무엇인가요? 모임 주최자분들이 장소 대관, 강습, 재료 구비 등 모임 진행을 준비하기 위해, 모임 진행일보다 일찍 신청을 마감합니다. 환불은 진행일이 아닌 신청 마감일 기준으로 이루어집니다. 모임마다 신청 마감일이 다르니, 꼭 날짜와 시간을 확인 후 결제해주세요! : ) ※신청 마감일 기준 환불 규정 예시 - 모임 진행일 : 10월 27일 - 신청 마감일 : 10월 26일 10월 25일에 취소 할 경우, 신청마감일 1일 전에 해당하며 50%의 수수료가 발생합니다. [환불 신청 방법] 1. 해당 모임 결제한 계정으로 로그인 2. 마이 - 신청내역 or 결제내역 3. 취소를 원하는 모임 상세 정보 버튼 - 취소 ※ 결제 수단에 따라 예금주, 은행명, 계좌번호 입력
+                            <div id="refund" class="Accordion__Content-sc-1jd6vdl-3 zRWUs">
+                                1. 결제 후 1시간 이내에는 무료 취소가 가능합니다. <br>(단, 신청마감 이후 취소 시, 모임 진행 당일 결제 후 취소 시 취소 및 환불 불가) <br>2. 결제 후 1시간이 초과한 경우, 아래의 환불규정에 따라 취소수수료가 부과됩니다. <br>- 신청마감 2일 이전 취소시 : 전액 환불 <br>- 신청마감 1일 ~ 신청마감 이전 취소시 : 결제 금액의 50% 취소 수수료 배상 후 환불 <br>- 신청마감 이후 취소시, 또는 당일 불참 : 환불 불가 <br>※ 다회권의 경우, 1회라도 사용시 부분 환불이 불가하며, 기간 내 주최자와 예약 확정 되지 않은 모임은 모임 포인트로 환불 됩니다.<br>※ 취소 수수료는 신청 마감일을 기준으로 산정됩니다. <br>※ 신청 마감일은 무엇인가요? 모임 주최자분들이 장소 대관, 강습, 재료 구비 등 모임 진행을 준비하기 위해, 모임 진행일보다 일찍 신청을 마감합니다.<br>환불은 진행일이 아닌 신청 마감일 기준으로 이루어집니다. 모임마다 신청 마감일이 다르니, 꼭 날짜와 시간을 확인 후 결제해주세요! : )<br>※신청 마감일 기준 환불 규정 예시<br> - 모임 진행일 : 10월 27일<br> - 신청 마감일 : 10월 26일 10월 25일에 취소 할 경우, 신청마감일 1일 전에 해당하며 50%의 수수료가 발생합니다. <br><br>[환불 신청 방법] <br>1. 해당 모임 결제한 계정으로 로그인<br>2. 마이 - 신청내역 or 결제내역<br>3. 취소를 원하는 모임 상세 정보 버튼 - 취소<br>※ 결제 수단에 따라 예금주, 은행명, 계좌번호 입력
                             </div>
                         </div>
                     </article>
@@ -364,15 +364,16 @@
                             <div th:unless="${groupScheduleDTO[0].groupScheduleDate < localDateTime}" class="FloatingActionBar__FloatingButtonWrapper-a3gyda-0 dIeHJQ">
                                 <button class="Button-bqxlp0-0 BUemN Button__StyledSubmitButton-sc-1dkzbac-0 eIJDxV" width="100%" height="56px" color="white" font-size="16px">
                                     <!--참여 취소-->
+                                    <!--groupUserCheck가 true이면 아직 참여 안했다는 것-->
                                     <div th:if="${groupUserCheck}">
-                                        <div class="DefaultButton__ActionLabel-sc-4mlqfg-0 cancelGroup">
-                                            참여 취소
+                                        <div class="DefaultButton__ActionLabel-sc-4mlqfg-0 joinGroup">
+                                            참여 하기
                                         </div>
                                     </div>
                                     <!--해당 모임에 아직 않았다면-->
                                     <div th:unless="${groupUserCheck}">
-                                        <div class="DefaultButton__ActionLabel-sc-4mlqfg-0 joinGroup">
-                                            참여 하기
+                                        <div class="DefaultButton__ActionLabel-sc-4mlqfg-0 cancelGroup">
+                                            참여 취소
                                         </div>
                                     </div>
                                 </button>

--- a/src/main/resources/templates/app/community/community.html
+++ b/src/main/resources/templates/app/community/community.html
@@ -165,15 +165,17 @@
 <footer th:replace="/app/fix/footer.html :: footer"></footer>
 </body>
 <script src="https://code.jquery.com/jquery-3.6.1.min.js"></script>
-<script src="/js/community/community.js"></script>
-<script src="/js/fix/header.js"></script>
-<script src="/js/community/communityClick.js"></script>
 <script>
     const $wrapper = $(".jIjcTX");
     $wrapper.next().css("overflow-x","unset");
     // $(".writeBtn").css("right","30.4%");
 
-    checkUser();
+    page = 1;
+
+    $(document).ready(function(){
+            console.log("들어옴");
+            checkUser();
+    })
 
     function checkUser(){
         if($("input[name='userId']").val()==""){
@@ -187,15 +189,17 @@
 
     // 화면 출력 함수 호출
     function show() {
-        communityService.getList(
-            page,
-        getList);
+        communityService.getList({
+            page: page,
+            keyword: globalThis.communityAr
+        }, getList);
     }
 
     function showWithOutUser() {
-        communityService.getListNotUser(
-            page,
-            getList);
+        communityService.getListNotUser({
+            page: page,
+            keyword: globalThis.communityAr
+        }, getList);
     }
 
     /*화면 출력*/
@@ -276,6 +280,7 @@
             if($("input[name='userId']").val()==""){
                 text+=`<img class="checkLike likePlus" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='21' height='18' viewBox='0 0 21 18'%3E %3Cpath fill='none' stroke='%234E5968' stroke-width='1.5' d='M15.657.75c-1.226 0-2.379.485-3.246 1.365l-1.91 1.94-1.912-1.94C7.722 1.235 6.57.75 5.343.75s-2.378.485-3.245 1.365C1.198 3.028.75 4.227.75 5.425c0 1.199.448 2.398 1.348 3.31l8.425 8.504 8.379-8.504c.9-.912 1.348-2.111 1.348-3.31 0-1.198-.448-2.397-1.347-3.31-.867-.88-2.02-1.365-3.246-1.365z'/%3E %3C/svg%3E" alt="좋아요~"><span class="likeNumber">`;
             }
+
             else if(!post.checkLike){
                 text+=`<img class="checkLike likeCancel" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='21' height='18' viewBox='0 0 21 18'%3E %3Cpath fill='%23F32D2D' d='M19.437 1.589C18.427.564 17.085 0 15.657 0s-2.77.564-3.78 1.589L10.5 2.986 9.124 1.59C8.114.564 6.77 0 5.344 0c-1.429 0-2.771.564-3.78 1.589-2.085 2.115-2.085 5.557 0 7.673l8.379 8.504c.148.15.348.234.557.234.209 0 .41-.084.557-.234l8.38-8.504c2.084-2.116 2.084-5.558 0-7.673z'/%3E %3C/svg%3E" alt="좋아요~"><span>`;
             }
@@ -304,4 +309,7 @@
         }
     }
 </script>
+<script src="/js/community/community.js"></script>
+<script src="/js/fix/header.js"></script>
+<script src="/js/community/communityClick.js"></script>
 </html>

--- a/src/main/resources/templates/app/community/community_comment.html
+++ b/src/main/resources/templates/app/community/community_comment.html
@@ -139,13 +139,13 @@
             console.log(reply.userId);
             let myId = $("input[name='myId']").val();
             if(postUserId == reply.userId){
-                if(reply.communityPostTitle == '고민'){
+                if(reply.communityPostTitle == '고민상담'){
                     text += "익명" + reply.communityReplyId + "     (작성자)";
                 } else{
                     text += reply.userNickName + "     (작성자)";
                 }
             } else{
-                if(reply.communityPostTitle == '고민'){
+                if(reply.communityPostTitle == '고민상담'){
                     text += "익명" + reply.communityReplyId;
                 } else{
                     text +=reply.userNickName;
@@ -162,7 +162,7 @@
             text +=``;
             <!--삭제 버튼-->
             text +=`</p>`
-            if(postUserId == reply.userId){
+            if($("input[name='myId']").val() == reply.userId){
                 text +=`<a class="deleteReply" onclick="return false" href=` + reply.communityReplyId;
                 text +=` class="ActionMenu__TextButton-s8lvsh-2 kosXvh goDelete">삭제</a>`;
             }

--- a/src/main/resources/templates/app/community/detail.html
+++ b/src/main/resources/templates/app/community/detail.html
@@ -190,7 +190,7 @@
                 <section class="ProductDetailPage__SectionContainer-sc-126q1k2-4 bremOa">
                     <article>
                         <div class="LinkAccordion__AccordionContainer-sc-1o112j5-1 cJPEOD">
-                            <div class="Accordion__Container-sc-1jd6vdl-0 eGMegW">
+                            <div id="noticeWrap" class="Accordion__Container-sc-1jd6vdl-0 eGMegW">
                                 <div>
                                     유의 사항
                                 </div>
@@ -198,8 +198,8 @@
                                     <img src="data:image/svg+xml,%3Csvg width='7' height='12' viewBox='0 0 7 12' fill='none' xmlns='http://www.w3.org/2000/svg'%3E %3Cpath d='M1 11L6 6L1 1' stroke='%23CCCCCC' stroke-linecap='round' stroke-linejoin='round'/%3E %3C/svg%3E" alt="Arrcodion arrow" class="Accordion__IconArrow-sc-1jd6vdl-2 ewyXrB">
                                 </div>
                             </div>
-                            <div class="Accordion__Content-sc-1jd6vdl-3 zRWUs">
-                                · 커뮤니티 성격과 상이한 내용이 기재될 경우, 예고없이 삭제 조치 될 수 있습니다. ·&nbsp;바르고 고운 말을 사용해주세요.
+                            <div id="notice" class="Accordion__Content-sc-1jd6vdl-3 zRWUs">
+                                · 커뮤니티 성격과 상이한 내용이 기재될 경우, 예고없이 삭제 조치 될 수 있습니다. <br> ·&nbsp;바르고 고운 말을 사용해주세요.
                             </div>
                         </div>
                     </article>

--- a/src/main/resources/templates/app/host/host.html
+++ b/src/main/resources/templates/app/host/host.html
@@ -40,10 +40,10 @@
 											<div class="row my-2">
 												<div class="col-lg-2">
 													<div class="mt-3 pl-3 text-wrap input-label-style" style="font-size: 0.9rem;">
-														<!----> 상품 <!---->
+														<!----> 모임 <!---->
 													</div>
 												</div>
-												<div class="col-lg-10">
+												<div id="groupHeader" class="col-lg-10">
 													<div>
 														<div data-v-59b7de29="" class="row">
 															<div data-v-59b7de29="" class="col">
@@ -68,7 +68,11 @@
 																<fieldset data-v-59b7de29="" class="form-group" id="__BVID__583">
 																	<div>
 																		<label class="form-control-label">검수상태</label>
-																		<div class="text-sm">
+																		<div th:if="${groupDTO}" class="text-sm">
+																			<div th:if="${#strings.equals(groupDTO.groupStatus, '승인대기')}" data-v-59b7de29="" class="text-muted font-weight-bold"> 검수 진행중 </div>
+																			<div th:unless="${#strings.equals(groupDTO.groupStatus, '승인대기')}" data-v-59b7de29="" class="text-muted font-weight-bold"> 검수 미신청 </div>
+																		</div>
+																		<div th:unless="${groupDTO}" class="text-sm">
 																			<div data-v-59b7de29="" class="text-muted font-weight-bold"> 검수 미신청 </div>
 																		</div>
 																	</div>
@@ -268,7 +272,6 @@
 																						<legend tabindex="-1" class="col-md-4 col-lg-2 bv-no-focus-ring col-form-label" id="__BVID__636__BV_label_">
 																							<span data-v-72dffd28="" class="text-danger position-absolute ml-2">*</span>
 																							<span data-v-72dffd28="" class="pl-3" style="font-size: 0.9rem;">모임명</span>
-																							<!---->
 																						</legend>
 																						<div class="col-md-8 col-lg-10">
 																							<div data-v-72dffd28="" class="input-group has-label w-100">
@@ -297,11 +300,9 @@
 																						<legend tabindex="-1" class="col-md-4 col-lg-2 bv-no-focus-ring col-form-label" id="__BVID__636__BV_label_">
 																							<span data-v-72dffd28="" class="text-danger position-absolute ml-2">*</span>
 																							<span data-v-72dffd28="" class="pl-3" style="font-size: 0.9rem;">카테고리</span>
-																							<!---->
 																						</legend>
 																						<div class="col-md-8 col-lg-10">
 																							<div data-v-72dffd28="" class="input-group has-label w-100">
-																								<!---->
 																								<input th:field="*{groupCategory}" name="groupCategory" data-v-72dffd28="" type="text" maxlength="40" required="required" placeholder="모임의 특징이 잘 드러나도록 카테고리를 입력해주세요." class="form-control">
 																								<div data-v-72dffd28="" class="input-group-append">
 																									<span data-v-72dffd28="" class="input-group-text">
@@ -309,12 +310,7 @@
 																									</span>
 																								</div>
 																							</div>
-																							<!---->
 																							<div data-v-72dffd28="" class="invalid-feedback" style="display: none;"> 카테고리는 필수입니다. 40자 이내로 입력해주세요. </div>
-																							<!---->
-																							<!---->
-																							<!---->
-																							<!---->
 																						</div>
 																					</div>
 																				</fieldset>
@@ -1249,11 +1245,11 @@
 															<fieldset class="form-group" id="__BVID__1035">
 																<div class="countryOption">
 																	<div class="my-2 custom-control custom-radio" data-value = "country" value="true">
-																		<input type="radio" name="isOverseas" class="custom-control-input" value="true" id="__BVID__1036">
+																		<input type="radio" name="isOverseas" class="custom-control-input" value="true" id="__BVID__1036" checked>
 																		<label class="custom-control-label" for="__BVID__1036">국내장소</label>
 																	</div>
 																	<div class="custom-control custom-radio" data-value = "foreign">
-																		<input type="radio" name="isOverseas" class="custom-control-input" value="false" id="__BVID__1037">
+																		<input type="radio" name="isOverseas" class="custom-control-input" value="false" id="__BVID__1037" disabled="">
 																		<label class="custom-control-label" for="__BVID__1037">해외장소</label>
 																	</div>
 																</div>
@@ -1287,9 +1283,6 @@
 																			<div data-v-307da538="" class="input-group">
 																				<input th:value="${groupDTO.groupLocationDetail}" data-v-307da538="" id="locationDetail" type="text" placeholder="상세주소를 입력해주세요." class="form-control">
 																			</div>
-																			<!---->
-																			<!---->
-																			<!---->
 																		</div>
 																	</fieldset>
 																</span>
@@ -1310,15 +1303,29 @@
 														<div>
 															<fieldset class="form-group mt-2" id="__BVID__1047">
 																<div>
-																	<div id="parkingOption" role="radiogroup" tabindex="-1" class="bv-no-focus-ring">
+																	<div th:if="${#strings.equals(groupDTO.groupParkingAvailable, '가능')}" id="parkingOption" role="radiogroup" tabindex="-1" class="bv-no-focus-ring">
 																		<div class="custom-control custom-control-inline custom-radio">
-																			<input id="parkingOption_BV_option_0" type="radio" name="isParkingAvailable" class="custom-control-input" value="true">
+																			<input id="parkingOption_BV_option_0" type="radio" name="isParkingAvailable" class="custom-control-input" value="true" checked>
 																			<label for="parkingOption_BV_option_0" class="custom-control-label">
 																				<span>가능</span>
 																			</label>
 																		</div>
 																		<div class="custom-control custom-control-inline custom-radio">
 																			<input id="parkingOption_BV_option_1" type="radio" name="isParkingAvailable" class="custom-control-input" value="false">
+																			<label for="parkingOption_BV_option_1" class="custom-control-label">
+																				<span>불가능</span>
+																			</label>
+																		</div>
+																	</div>
+																	<div th:unless="${#strings.equals(groupDTO.groupParkingAvailable, '가능')}" id="parkingOption" role="radiogroup" tabindex="-1" class="bv-no-focus-ring">
+																		<div class="custom-control custom-control-inline custom-radio">
+																			<input id="parkingOption_BV_option_0" type="radio" name="isParkingAvailable" class="custom-control-input" value="false">
+																			<label for="parkingOption_BV_option_0" class="custom-control-label">
+																				<span>가능</span>
+																			</label>
+																		</div>
+																		<div class="custom-control custom-control-inline custom-radio">
+																			<input id="parkingOption_BV_option_1" type="radio" name="isParkingAvailable" class="custom-control-input" value="true" checked>
 																			<label for="parkingOption_BV_option_1" class="custom-control-label">
 																				<span>불가능</span>
 																			</label>
@@ -1396,6 +1403,9 @@
 
 	resizeApply();
 
+	function showHeader(){
+		groupSave.hostHeader(param, hostHeader);
+	}
 
 
 


### PR DESCRIPTION
버그 수정 사항

참여 현황에 인원 표기 잘 되도록 진행
유의사항/환불 정책 클릭이 안됨
검수 요청 후에는 수정이 불가하도록 STATUS 추가?
상단부 모임 헤더부분에 상품이라고 기재되어 있는 것 텍스트 삭제
모임 출력되는 화면을 STATUS가 APPROVED인 것만 나오도록 함
이런 모임 어때요 창에 STATUS가 APPROVED인 것만 나오도록
(오프라인 모임) 수정 진행 시 진행장소 추가 부분의 테이블이 안나옴
(오프라인 모임) 수정 시 장소여부 체크가 안되어있음
(오프라인 모임) 수정 시 주차 가능여부, 추가 안내사항 안나옴
금액 설정 유효성 검사 진행 필요
오프라인 진행 시 장소 유효성 검사 필요
모임 캘린더에 일정 처리 후 등록 모달창이 또 나옴
모임 캘린더 일정 처리 후 알람창이 누적되서 나옴
모임 캘린더 날짜 클릭 시 날짜가 자동으로 들어오지 않음
모임 신청/취소 정확하게 나오도록 진행
비회원 유저는 모임 게시글 못들어가는 오류
모임 전체 개수
유의사항 클릭이 안됨
무한스크롤 시 필터가 첫 페이지의 10개만 되고 스크롤 이후부턴 안됨
모임과 같이 상세페이지 레이아웃 수정
일기 작성 시 태그 수정
고민 게시판 댓글 익명으로 표기가 안되고 있음
고민 게시판 댓글 안썼으면 등록 안되게 유효성 검사
댓글 오름차순으로 정렬
커뮤니티 댓글 삭제 버튼 구현
필터 선택 안했을 때 무한 스크롤 되게 하기
하트 표시 제대로 나오게 지정 - 첫 페이지만 이상함